### PR TITLE
Fix error checking themes with empty colors

### DIFF
--- a/app/helpers/concerns/decidim/accountability_simple/application_helper_extensions.rb
+++ b/app/helpers/concerns/decidim/accountability_simple/application_helper_extensions.rb
@@ -64,7 +64,7 @@ module Decidim
         return accountability_icon(detail.icon) if detail && !detail.icon.empty?
 
         color_parent = result
-        color_parent = color_parent.parent while color_parent.parent && color_parent.theme_color.empty?
+        color_parent = color_parent.parent while color_parent.parent && color_parent.theme_color.blank?
 
         color = color_parent.theme_color || default_theme_color
         style = "background-color: #{color};"


### PR DESCRIPTION
While I was testing this module I found an error due the default status for `theme_color` is to be `nil` and the `empty?` method fails.